### PR TITLE
Implement simple map builder framework

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         build-type: [debug, release]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
       if: ${{ matrix.build-type == 'debug' }}
       run: cargo fmt --all --check
     - name: Clippy
-      run: cargo clippy --no-deps ${{ matrix.build-flag }}
+      run: cargo clippy --no-deps ${{ matrix.build-flag }} -- -Dwarnings
     - name: Check licenses
       if: ${{ matrix.build-type == 'debug' }}
       run: cargo deny check licenses

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 [dependencies]
 bevy = { version = "0.7", features = ["dynamic"] }
 bevy-inspector-egui = { version = "0.11" }
+clap = { version = "3.2.12", features = ["derive"] }
 rand = { version = "0.8" }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -30,27 +30,32 @@ fn move_actors(
                 if mov.dx >= 0 {
                     p.x + mov.dx as u32
                 } else {
-                    p.x - mov.dx.abs() as u32
+                    p.x - mov.dx.unsigned_abs()
                 }
             },
             y: {
                 if mov.dy.is_positive() {
                     p.y + mov.dy as u32
                 } else {
-                    p.y - mov.dy.abs() as u32
+                    p.y - mov.dy.unsigned_abs()
                 }
             },
         };
         if let Ok(idx) = map.xy_to_idx(next.x, next.y) {
             if map.tiles[idx] == TileType::Floor {
                 *p = next;
-                commands.entity(e).remove::<TakingTurn>();
             } else {
                 warn!("Cannot move {e:?} to tile {}, {}", next.x, next.y);
             }
         }
-        // Need to remove move intent component no matter what
-        commands.entity(e).remove::<WantsToMove>();
+        // Remove move intent and turn taking components no matter what
+        // TODO: This is slightly incorrect since it means moving into a wall
+        // means skipping / losing a turn, but it avoids deadlocks in case the
+        // player moves into a wall and the GameState does not reset correctly
+        commands
+            .entity(e)
+            .remove::<WantsToMove>()
+            .remove::<TakingTurn>();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod actions;
 mod components;
 mod input_handler;
 mod map;
+mod map_builder;
 mod monster_ai;
 mod render;
 mod spawner;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,33 @@
+#![deny(missing_docs)]
+
+//! Main entrypoint for this roguelike project
+
 use bevy::prelude::*;
+use clap::Parser;
 
 #[cfg(debug_assertions)]
 use bevy_inspector_egui::{RegisterInspectable, WorldInspectorPlugin};
 
+/// Describes the parameters that may be passed from the CLI
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct CLIArgs {
+    /// What map builder to use
+    #[clap(short = 'm', long = "map", value_enum, default_value = "rooms")]
+    map_builder: map::MapBuilder,
+}
+
+/// All possible game states
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum GameState {
+    /// Waiting for player input
     WaitingForPlayer,
+    /// Iterating through all active actors to resolve their actions
     Ticking,
 }
 
 #[cfg(debug_assertions)]
+/// Adds various debugging tools
 struct DebugPlugin;
 
 #[cfg(debug_assertions)]
@@ -23,10 +41,14 @@ impl Plugin for DebugPlugin {
 }
 
 fn main() {
+    let args = CLIArgs::parse();
+
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
         .add_state(GameState::Ticking)
-        .add_plugin(map::MapPlugin)
+        .add_plugin(map::MapPlugin {
+            builder: args.map_builder,
+        })
         .add_plugin(render::RenderPlugin)
         .add_plugin(spawner::SpawningPlugin)
         .add_plugin(actions::ActionPlugin)

--- a/src/map_builder/arbitrary_starting_point.rs
+++ b/src/map_builder/arbitrary_starting_point.rs
@@ -1,0 +1,43 @@
+use rand::Rng;
+
+use super::{MapBuildData, MapModifier, MapRng};
+use crate::map::TileType;
+
+pub struct ArbitraryStartingPoint;
+
+impl ArbitraryStartingPoint {
+    pub fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+}
+
+impl MapModifier for ArbitraryStartingPoint {
+    fn modify_map(&mut self, rng: &mut MapRng, build_data: &mut MapBuildData) {
+        let random_idx = rng.gen_range(0..build_data.map.length());
+        if let Some((starting_idx, _)) = build_data
+            .map
+            .tiles
+            .iter()
+            .enumerate()
+            .skip(random_idx)
+            .find(|&(_, t)| *t == TileType::Floor)
+        {
+            let start_pos = build_data.map.idx_to_xy(starting_idx).unwrap();
+            build_data.metadata.starting_position = Some(start_pos);
+        } else if let Some((starting_idx, _)) = build_data
+            .map
+            .tiles
+            .iter()
+            .enumerate()
+            .take(random_idx)
+            .rev()
+            .find(|&(_, t)| *t == TileType::Floor)
+        {
+            let start_pos = build_data.map.idx_to_xy(starting_idx).unwrap();
+            build_data.metadata.starting_position = Some(start_pos);
+        } else {
+            panic!("Cannot find a single floor tile as the starting position!");
+        }
+        build_data.take_snapshot();
+    }
+}

--- a/src/map_builder/cellular_builder.rs
+++ b/src/map_builder/cellular_builder.rs
@@ -1,0 +1,88 @@
+use rand::Rng;
+
+use super::{InitialMapBuilder, MapBuildData, MapRng};
+use crate::map::TileType;
+
+pub struct CellularAutomataBuilder {
+    iterations: i32,
+    floor_likelihood: f64,
+    neighbors_for_wall: Vec<i32>,
+}
+
+impl CellularAutomataBuilder {
+    pub fn new(
+        iterations: i32,
+        floor_likelihood: f64,
+        neighbors_for_wall: Vec<i32>,
+    ) -> Box<CellularAutomataBuilder> {
+        Box::new(CellularAutomataBuilder {
+            iterations,
+            floor_likelihood,
+            neighbors_for_wall,
+        })
+    }
+}
+
+impl InitialMapBuilder for CellularAutomataBuilder {
+    fn build_map(&mut self, rng: &mut MapRng, build_data: &mut MapBuildData) {
+        // Completely randomize the map initially
+        for y in 1..build_data.map.height - 1 {
+            for x in 1..build_data.map.width - 1 {
+                let idx = build_data.map.xy_to_idx(x, y).unwrap();
+                if rng.gen_bool(self.floor_likelihood) {
+                    build_data.map.tiles[idx] = TileType::Floor;
+                } else {
+                    build_data.map.tiles[idx] = TileType::Wall;
+                }
+            }
+        }
+        build_data.take_snapshot();
+
+        // Iterate cellular automata rules
+        for _i in 0..self.iterations {
+            let mut new_tiles = build_data.map.tiles.clone();
+
+            let height = build_data.map.height;
+            let width = build_data.map.width;
+            for y in 1..height - 1 {
+                for x in 1..width - 1 {
+                    let idx = build_data.map.xy_to_idx(x, y).unwrap();
+                    let mut neighbors = 0;
+                    if build_data.map.tiles[idx - 1] == TileType::Wall {
+                        neighbors += 1;
+                    }
+                    if build_data.map.tiles[idx + 1] == TileType::Wall {
+                        neighbors += 1;
+                    }
+                    if build_data.map.tiles[idx - width as usize] == TileType::Wall {
+                        neighbors += 1;
+                    }
+                    if build_data.map.tiles[idx + width as usize] == TileType::Wall {
+                        neighbors += 1;
+                    }
+                    if build_data.map.tiles[idx - (width as usize - 1)] == TileType::Wall {
+                        neighbors += 1;
+                    }
+                    if build_data.map.tiles[idx - (width as usize + 1)] == TileType::Wall {
+                        neighbors += 1;
+                    }
+                    if build_data.map.tiles[idx + (width as usize - 1)] == TileType::Wall {
+                        neighbors += 1;
+                    }
+                    if build_data.map.tiles[idx + (width as usize + 1)] == TileType::Wall {
+                        neighbors += 1;
+                    }
+
+                    if self.neighbors_for_wall.contains(&neighbors) {
+                        new_tiles[idx] = TileType::Wall;
+                    } else {
+                        new_tiles[idx] = TileType::Floor;
+                    }
+                }
+            }
+
+            build_data.map.tiles = new_tiles;
+            build_data.take_snapshot();
+        }
+    }
+}

--- a/src/map_builder/mod.rs
+++ b/src/map_builder/mod.rs
@@ -1,0 +1,93 @@
+use crate::map::{GameMap, MapMetadata};
+
+pub type MapRng = rand::rngs::StdRng;
+
+pub mod arbitrary_starting_point;
+pub mod cellular_builder;
+pub mod rect;
+pub mod simple_map_builder;
+
+/// Combines abstract map properties, the concrete tile layout, and potentially a history of snapshots
+pub struct MapBuildData {
+    map: GameMap,
+    metadata: MapMetadata,
+    pub history: Vec<(GameMap, MapMetadata)>,
+}
+
+impl MapBuildData {
+    /// Adds a snapshot of the current map state to the history
+    pub fn take_snapshot(&mut self) {
+        let snapshot = self.map.clone();
+        self.history.push((snapshot, self.metadata.clone()));
+    }
+}
+
+/// Interface to build an initial base map. There can only be a single [InitialMapBuilder] in a [BuilderChain].
+pub trait InitialMapBuilder: Send + Sync {
+    fn build_map(&mut self, rng: &mut MapRng, build_data: &mut MapBuildData);
+}
+
+/// Interface for 'map modifiers' that may be applied in a stack.
+pub trait MapModifier: Send + Sync {
+    fn modify_map(&mut self, rng: &mut MapRng, build_data: &mut MapBuildData);
+}
+
+pub struct Uninitialized;
+pub struct HasInitial {
+    builder: Box<dyn InitialMapBuilder>,
+}
+
+pub trait InitialMapBuilderTrait {}
+impl InitialMapBuilderTrait for Uninitialized {}
+impl InitialMapBuilderTrait for HasInitial {}
+
+/// Collects a sequence of map building steps with at most one [InitialMapBuilder] and multiple [MapModifier]s
+pub struct BuilderChain<Initialized: InitialMapBuilderTrait> {
+    initial: Initialized,
+    modifiers: Vec<Box<dyn MapModifier>>,
+    build_data: MapBuildData,
+}
+
+const WIDTH: u32 = 80;
+const HEIGHT: u32 = 53;
+
+impl BuilderChain<Uninitialized> {
+    pub fn new() -> BuilderChain<Uninitialized> {
+        BuilderChain {
+            initial: Uninitialized,
+            modifiers: Vec::new(),
+            build_data: MapBuildData {
+                map: GameMap::new(WIDTH, HEIGHT),
+                metadata: MapMetadata::default(),
+                history: Vec::new(),
+            },
+        }
+    }
+
+    pub fn start_with(self, initial: Box<dyn InitialMapBuilder>) -> BuilderChain<HasInitial> {
+        BuilderChain {
+            initial: HasInitial { builder: initial },
+            modifiers: self.modifiers,
+            build_data: self.build_data,
+        }
+    }
+}
+
+impl<I: InitialMapBuilderTrait> BuilderChain<I> {
+    pub fn with(&mut self, builder: Box<dyn MapModifier>) -> &mut Self {
+        self.modifiers.push(builder);
+        self
+    }
+}
+
+impl BuilderChain<HasInitial> {
+    pub fn build_map(mut self, rng: &mut MapRng) -> (GameMap, MapMetadata) {
+        self.initial.builder.build_map(rng, &mut self.build_data);
+
+        for builder in self.modifiers.iter_mut() {
+            builder.modify_map(rng, &mut self.build_data);
+        }
+
+        (self.build_data.map, self.build_data.metadata)
+    }
+}

--- a/src/map_builder/rect.rs
+++ b/src/map_builder/rect.rs
@@ -1,0 +1,28 @@
+#[derive(Debug, Clone)]
+pub struct Rect {
+    pub x1: u32,
+    pub x2: u32,
+    pub y1: u32,
+    pub y2: u32,
+}
+
+impl Rect {
+    /// TODO: Enforce that width and height are positive or swap the corner points around accordingly
+    pub fn new(x: u32, y: u32, width: u32, height: u32) -> Rect {
+        Rect {
+            x1: x,
+            y1: y,
+            x2: x + width,
+            y2: y + height,
+        }
+    }
+
+    /// Return true if self intersects with other
+    pub fn intersect(&self, other: &Rect) -> bool {
+        self.x1 <= other.x2 && self.x2 >= other.x1 && self.y1 <= other.y2 && self.y2 >= other.y1
+    }
+
+    pub fn center(&self) -> (u32, u32) {
+        ((self.x1 + self.x2) / 2, (self.y1 + self.y2) / 2)
+    }
+}

--- a/src/map_builder/simple_map_builder.rs
+++ b/src/map_builder/simple_map_builder.rs
@@ -35,7 +35,7 @@ impl SimpleMapBuilder {
             let x = rng.gen_range(0..build_data.map.width - w - 1);
             let y = rng.gen_range(0..build_data.map.height - h - 1);
             let new_room = Rect::new(x, y, w, h);
-            let ok = !rooms.iter().any(|r| new_room.intersect(&r));
+            let ok = !rooms.iter().any(|r| new_room.intersect(r));
             if ok {
                 apply_room_to_map(&mut build_data.map, &new_room);
                 if !rooms.is_empty() {

--- a/src/map_builder/simple_map_builder.rs
+++ b/src/map_builder/simple_map_builder.rs
@@ -1,0 +1,107 @@
+use bevy::log::*;
+use rand::Rng;
+use std::cmp::{max, min};
+
+use super::{rect::Rect, InitialMapBuilder, MapBuildData, MapRng};
+use crate::map::{GameMap, TileType};
+
+pub struct SimpleMapBuilder {
+    max_rooms: u32,
+    min_size: u32,
+    max_size: u32,
+}
+
+impl InitialMapBuilder for SimpleMapBuilder {
+    fn build_map(&mut self, rng: &mut MapRng, build_data: &mut MapBuildData) {
+        self.rooms_and_corridors(rng, build_data);
+    }
+}
+
+impl SimpleMapBuilder {
+    pub fn new(max_rooms: u32, min_size: u32, max_size: u32) -> Box<SimpleMapBuilder> {
+        Box::new(SimpleMapBuilder {
+            max_rooms,
+            min_size,
+            max_size,
+        })
+    }
+
+    fn rooms_and_corridors(&mut self, rng: &mut MapRng, build_data: &mut MapBuildData) {
+        let mut rooms = Vec::new();
+
+        for _ in 0..self.max_rooms {
+            let w = rng.gen_range(self.min_size..=self.max_size);
+            let h = rng.gen_range(self.min_size..=self.max_size);
+            let x = rng.gen_range(0..build_data.map.width - w - 1);
+            let y = rng.gen_range(0..build_data.map.height - h - 1);
+            let new_room = Rect::new(x, y, w, h);
+            let ok = !rooms.iter().any(|r| new_room.intersect(&r));
+            if ok {
+                apply_room_to_map(&mut build_data.map, &new_room);
+                if !rooms.is_empty() {
+                    let (new_x, new_y) = new_room.center();
+                    let (prev_x, prev_y) = rooms[rooms.len() - 1].center();
+                    apply_tunnel(
+                        &mut build_data.map,
+                        prev_x,
+                        prev_y,
+                        new_x,
+                        new_y,
+                        rng.gen_bool(0.5),
+                    );
+                }
+
+                rooms.push(new_room);
+                build_data.take_snapshot();
+            }
+        }
+        build_data.metadata.rooms = Some(rooms);
+    }
+}
+
+/// Marks all tiles strictly inside the given room as floor tiles
+fn apply_room_to_map(map: &mut GameMap, room: &Rect) {
+    for y in room.y1 + 1..room.y2 {
+        for x in room.x1 + 1..room.x2 {
+            if let Ok(idx) = map.xy_to_idx(x, y) {
+                map.tiles[idx] = TileType::Floor;
+            } else {
+                warn!(
+                    "Cannot make {x}, {y} part of a room, it is outside the map ({} x {})!",
+                    map.width, map.height
+                );
+            }
+        }
+    }
+}
+
+/// Carves a dogleg path of floor tiles into the map from (x1, y1) to (x2, y2)
+fn apply_tunnel(map: &mut GameMap, x1: u32, y1: u32, x2: u32, y2: u32, horizontal_first: bool) {
+    if horizontal_first {
+        apply_horizontal_tunnel(map, x1, x2, y1);
+        apply_vertical_tunnel(map, y1, y2, x2);
+    } else {
+        apply_vertical_tunnel(map, y1, y2, x1);
+        apply_horizontal_tunnel(map, x1, x2, y2);
+    }
+}
+
+fn apply_horizontal_tunnel(map: &mut GameMap, x1: u32, x2: u32, y: u32) {
+    for x in min(x1, x2)..=max(x1, x2) {
+        if let Ok(idx) = map.xy_to_idx(x, y) {
+            map.tiles[idx] = TileType::Floor;
+        } else {
+            warn!("Cannot make {x}, {y} part of a tunnel, it is outside the map {map:?}!");
+        }
+    }
+}
+
+fn apply_vertical_tunnel(map: &mut GameMap, y1: u32, y2: u32, x: u32) {
+    for y in min(y1, y2)..=max(y1, y2) {
+        if let Ok(idx) = map.xy_to_idx(x, y) {
+            map.tiles[idx] = TileType::Floor;
+        } else {
+            warn!("Cannot make {x}, {y} part of a tunnel, it is outside the map {map:?}!");
+        }
+    }
+}

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -95,7 +95,7 @@ fn spawn_tiles(
         let wall_atlas =
             TextureAtlas::from_grid(wall_handle, Vec2::new(SPRITE_SIZE, SPRITE_SIZE), 20, 51);
         let wall_atlas_handle = texture_atlases.add(wall_atlas);
-        let mut sprite = TextureAtlasSprite::new(63);
+        let mut sprite = TextureAtlasSprite::new(243);
         sprite.custom_size = Some(Vec2::new(TILE_SIZE, TILE_SIZE));
         (sprite, wall_atlas_handle)
     };

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 use crate::{
     components::{Actor, Monster, Player, Position},
-    map::{GameMap, TileType},
+    map::{GameMap, MapMetadata, TileType},
     render::TILE_SIZE,
 };
 
@@ -26,6 +26,7 @@ fn setup_player(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
+    map_metadata: Res<MapMetadata>,
 ) {
     let texture_handle = asset_server.load("Dawnlike/Characters/Pest0.png");
     let texture_atlas =
@@ -33,6 +34,8 @@ fn setup_player(
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
     let mut sprite = TextureAtlasSprite::new(59);
     sprite.custom_size = Some(Vec2::new(TILE_SIZE, TILE_SIZE));
+
+    let start = map_metadata.starting_position.unwrap();
     commands
         .spawn_bundle(SpriteSheetBundle {
             texture_atlas: texture_atlas_handle,
@@ -41,7 +44,7 @@ fn setup_player(
             ..default()
         })
         .insert(Player)
-        .insert(Position::new(18, 23))
+        .insert(Position::new(start.0, start.1))
         .insert(Actor::default());
 }
 
@@ -65,7 +68,7 @@ fn spawn_monster(
             ..default()
         })
         .insert(Monster)
-        .insert(Position::new(20, 30))
+        .insert(Position::new(30, 48))
         .insert(Actor::default());
 }
 


### PR DESCRIPTION
Currently provides cellular automata map builder, simple room-based
builder, and 'map modifier' that selects a random starting position
for the player.
Map builders are made up of a single initial map builder generating
the overall map layout according to some algorithm and susbequent
map modifiers that can place entities, add map features, modify some
regions...
The map builder framework uses the type state pattern to enforce
presence of an initial map builder at compile time rather than relying
on Optional and runtime checks.
Map builder for the game is currently hardcoded.